### PR TITLE
Fix for battery problem with residual tolerance

### DIFF
--- a/pySDC/implementations/problem_classes/Battery.py
+++ b/pySDC/implementations/problem_classes/Battery.py
@@ -77,8 +77,9 @@ class battery_n_capacitors(ptype):
             'nvars', 'ncapacitors', 'Vs', 'Rs', 'C', 'R', 'L', 'alpha', 'V_ref', localVars=locals(), readOnly=True
         )
 
-        self.A = np.zeros((n + 1, n + 1))
         self.switch_A, self.switch_f = self.get_problem_dict()
+        self.A = self.switch_A[0]
+
         self.t_switch = None
         self.nswitches = 0
 

--- a/pySDC/projects/PinTSimE/battery_2capacitors_model.py
+++ b/pySDC/projects/PinTSimE/battery_2capacitors_model.py
@@ -67,7 +67,7 @@ def run():
     problem_classes = [battery_n_capacitors]
     sweeper_classes = [imex_1st_order]
     num_nodes = 4
-    restol = -1
+    restol = 1e-8
     maxiter = 12
 
     ncapacitors = 2


### PR DESCRIPTION
I am not sure that I fixed completely, but at least it now does something when you supply a residual tolerance larger 0. The problem was that the `A` matrix was only changed from zeros in the solve system function. Before this was called, however the right hand side was computed and there was zero change in the solution, so the residual was also zero and there was nothing to solve. If you initialise the `A` matrix correctly in the `__init__` function, this does not happen.
I don't know anything about your problem, though. I started this PR to show where a fix is needed, but I don't know if this changes the behaviour of the problem for the worse in some other part. In particular, the test does not pass anymore because the iteration count is now different. Feel free to reject the PR and fix the issue in some other manner!